### PR TITLE
Feat/ensure h1 seo best practices (#9) Closes #7

### DIFF
--- a/public-site/src/components/header.js
+++ b/public-site/src/components/header.js
@@ -4,12 +4,13 @@ import { Link } from "gatsby"
 
 import Navigation from "./navigation"
 
-const SiteHeading1 = ({ className, children }) => (
-  <h1 className={className}>{children}</h1>
+const SiteHeading = ({ className, children }) => (
+  <h4 className={className}>{children}</h4>
 )
 
-const StyledSiteHeading1 = styled(SiteHeading1)`
+const StyledSiteHeading = styled(SiteHeading)`
   margin: 0;
+  font-size: 2rem;
 `
 
 const HeaderWrapper = ({ className, children }) => (
@@ -41,9 +42,9 @@ const HeaderComponent = ({ siteTitle, navLinks }) => (
   <StyledHeader>
     <StyledHeaderWrapper>
       <Navigation navLinks={navLinks} />
-      <StyledSiteHeading1>
+      <StyledSiteHeading>
         <StyledLink to="/">{siteTitle}</StyledLink>
-      </StyledSiteHeading1>
+      </StyledSiteHeading>
     </StyledHeaderWrapper>
   </StyledHeader>
 )

--- a/public-site/src/notes/aws-cert.md
+++ b/public-site/src/notes/aws-cert.md
@@ -2,7 +2,7 @@
 title: "What AWS Certification should I get?"
 ---
 
-## What are they and why do they matter
+## What are AWS Certifications and are they worth it
 
 AWS, like most other vendors of... well, anything, has a certification program. These are used to validate basic competency in a few areas. It can be related to services, application experience, domain knowledge, or a mix of all three. Obtaining a certification will be an act in 3 parts:
 

--- a/public-site/src/templates/devtip.js
+++ b/public-site/src/templates/devtip.js
@@ -11,7 +11,7 @@ const DevtipsDetailTemplate = ({ data }) => (
       description={data.markdownRemark.frontmatter.description}
     />
     <BackToListNav destination="/devtips/" name="Back to devtips" />
-    <h4>{data.markdownRemark.frontmatter.title}</h4>
+    <h1>{data.markdownRemark.frontmatter.title}</h1>
     <p>{data.markdownRemark.frontmatter.date}</p>
     <div dangerouslySetInnerHTML={{ __html: data.markdownRemark.html }} />
   </Layout>

--- a/public-site/src/templates/note.js
+++ b/public-site/src/templates/note.js
@@ -8,7 +8,7 @@ const DevtipsDetailTemplate = ({ data }) => (
   <Layout>
     <SEO title={data.markdownRemark.frontmatter.title} />
     <BackToListNav destination="/notes/" name="Back to notes" />
-    <h4>{data.markdownRemark.frontmatter.title}</h4>
+    <h1>{data.markdownRemark.frontmatter.title}</h1>
     <div dangerouslySetInnerHTML={{ __html: data.markdownRemark.html }} />
   </Layout>
 )


### PR DESCRIPTION
* Remove use of H1 in site header, replace with styles

* Ensure content titles get an h1

* Make note h2 more meaningful